### PR TITLE
Deprecation of SetMap in CIShell Utilities.

### DIFF
--- a/core/org.cishell.utilities/META-INF/MANIFEST.MF
+++ b/core/org.cishell.utilities/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Utilities Plug-in
 Bundle-SymbolicName: org.cishell.utilities
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: com.google.common.annotations;version="8.0.0",
  com.google.common.base;version="8.0.0",
@@ -29,7 +29,7 @@ Import-Package: com.google.common.annotations;version="8.0.0",
  prefuse.data.util,
  prefuse.util,
  prefuse.util.collections
-Export-Package: org.cishell.utilities,
+Export-Package: org.cishell.utilities;version="1.0.1",
  org.cishell.utilities.color,
  org.cishell.utilities.database,
  org.cishell.utilities.dictionary,

--- a/core/org.cishell.utilities/pom.xml
+++ b/core/org.cishell.utilities/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.cishell.core</groupId>
   <artifactId>org.cishell.utilities</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/org.cishell.utilities/src/org/cishell/utilities/SetMap.java
+++ b/core/org.cishell.utilities/src/org/cishell/utilities/SetMap.java
@@ -5,6 +5,10 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Don't use this! Instead use a SetMultimap from Google Guava!
+ */
+@Deprecated
 public class SetMap {	
 	private Map map = new Hashtable();
 	


### PR DESCRIPTION
The SetMap should be replaced with Guava's Multimap.
