### PR TITLE
Adding ".hmap" file extension checking to readHeaderProperties method

### DIFF
--- a/core/org.cishell.utilities/META-INF/MANIFEST.MF
+++ b/core/org.cishell.utilities/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: com.google.common.annotations;version="8.0.0",
  com.google.common.base;version="8.0.0",
  com.google.common.collect;version="8.0.0",
+ org.apache.commons.io;version="2.1.0",
  org.cishell.framework;version="1.0.0",
  org.cishell.framework.algorithm;version="1.0.0",
  org.cishell.framework.data,

--- a/core/org.cishell.utilities/src/org/cishell/utilities/TableUtilities.java
+++ b/core/org.cishell.utilities/src/org/cishell/utilities/TableUtilities.java
@@ -21,6 +21,7 @@ import prefuse.util.collections.IntIterator;
 
 import org.cishell.framework.algorithm.AlgorithmExecutionException;
 import org.osgi.service.log.LogService;
+import org.apache.commons.io.FilenameUtils;
 
 /**
  * @deprecated see
@@ -367,11 +368,17 @@ public class TableUtilities {
 	/**
 	 * Reads a properties file mapping data type specific headers to the desired headers.
 	 * 
-	 * @param propLocation	A URL representing the location of said properties file
+	 * @param propLocation	A URL representing the location of a .hmap format properties file
 	 * @return	A String-to-String Map, with old header values as keys, and their replacements as values
 	 * @throws IOException	If there is an IO error reading the properties file
 	 */
 	private static Map<String, String> readHeaderProperties(URL propLocation) throws IOException {
+		
+		// throws exception if properties file does not have .hmap (header map) extension
+		String extension = FilenameUtils.getExtension(propLocation.getPath());
+		if (!extension.equals("hmap"))
+			throw new IOException("The given file extension is incompatible with this plugin. Please use a .hmap extension file instead.");
+		
 		InputStream in = propLocation.openStream();
 		Reader reader = new InputStreamReader(in, "UTF-8");
 


### PR DESCRIPTION
I added file extension checking to a method in the TableUtilities file, which will be used to support our new .hmap file extension and ensure that users only use this file type with our new plugin.
